### PR TITLE
Upgrade CI to Node 22

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         run: npm ci || npm install


### PR DESCRIPTION
Astro 6 requires Node >=22.12.0; bump setup-node from 20 to 22.

https://claude.ai/code/session_01FH1zwtLFWYRnMLKejZqD2z