### PR TITLE
fix: replace ViewTransitions with ClientRouter for Astro v5+ compatibility

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,5 @@
 ---
-import { ViewTransitions } from 'astro:transitions';
+import { ClientRouter } from 'astro:transitions';
 
 interface Props {
   title?: string;
@@ -25,7 +25,7 @@ const currentPath = Astro.url.pathname;
   <link href="https://fonts.googleapis.com/css?family=Mitr:400,300" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css?family=Slabo+27px" rel="stylesheet">
 
-  <ViewTransitions />
+  <ClientRouter />
 
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-41266080-1"></script>


### PR DESCRIPTION
ViewTransitions was renamed to ClientRouter in Astro v5. Update the import
and component usage in BaseLayout.astro to fix the build error.

https://claude.ai/code/session_01CY1gRXPJqGThWVK8f6Gmse