### PR TITLE
feat: enhance view transitions with clip-path wipe, sliding nav indicator, and page accent stripe

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,9 +4,10 @@ import { ClientRouter } from 'astro:transitions';
 interface Props {
   title?: string;
   description?: string;
+  pageColor?: string;
 }
 
-const { title = 'Paola Valdivia', description = 'Senior Software Engineer - React, TypeScript, C#, Data Visualization' } = Astro.props;
+const { title = 'Paola Valdivia', description = 'Senior Software Engineer - React, TypeScript, C#, Data Visualization', pageColor = '#0a402b' } = Astro.props;
 const currentPath = Astro.url.pathname;
 ---
 
@@ -37,7 +38,7 @@ const currentPath = Astro.url.pathname;
   </script>
 </head>
 <body>
-  <nav class="navbar" transition:name="site-nav" transition:animate="fade">
+  <nav class="navbar">
     <div class="container">
       <a href="/" class="logo">Paola Valdivia</a>
       <ul class="nav-links">
@@ -46,14 +47,17 @@ const currentPath = Astro.url.pathname;
         <li><a href="/publications" class={currentPath === '/publications' ? 'active' : ''}>Publications</a></li>
         <li><a href="/cv" class={currentPath === '/cv' ? 'active' : ''}>CV</a></li>
       </ul>
+      <span class="nav-indicator" id="nav-indicator"></span>
     </div>
   </nav>
 
-  <main>
+  <div class="page-stripe" transition:name="page-stripe" style={`background-color: ${pageColor}`}></div>
+
+  <main transition:name="main-content">
     <slot />
   </main>
 
-  <footer transition:name="site-footer" transition:animate="fade">
+  <footer>
     <div class="container">
       <div class="social-links">
         <a href="https://github.com/paolavaldivia" target="_blank" rel="noopener" title="GitHub">
@@ -136,6 +140,7 @@ const currentPath = Astro.url.pathname;
       padding: 0.8rem 0;
       border-bottom: 1px solid #e0ddd8;
       font-variant: small-caps;
+      position: relative;
     }
 
     .navbar .container {
@@ -183,6 +188,27 @@ const currentPath = Astro.url.pathname;
       -webkit-text-fill-color: var(--green);
       background: none;
       color: var(--green);
+    }
+
+    /* Sliding nav indicator (magic line) */
+    .nav-indicator {
+      position: absolute;
+      bottom: 0;
+      height: 3px;
+      background-color: var(--terracotta);
+      border-radius: 2px 2px 0 0;
+      transition:
+        left 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+        width 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+        opacity 0.2s;
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    /* Page color stripe (C) */
+    .page-stripe {
+      height: 4px;
+      width: 100%;
     }
 
     /* Main content */
@@ -246,78 +272,84 @@ const currentPath = Astro.url.pathname;
 
       h1 { font-size: 1.8rem; }
       h2 { font-size: 1.3rem; }
+
+      .nav-indicator {
+        display: none;
+      }
     }
 
-    /* View Transitions */
-    @keyframes slide-from-right {
-      from { opacity: 0; transform: translateX(24px); }
+    /* =====================
+       VIEW TRANSITIONS
+       ===================== */
+
+    /* Root (nav + footer + bg): instant swap — no distracting flash */
+    ::view-transition-old(root),
+    ::view-transition-new(root) {
+      animation: none;
+      mix-blend-mode: normal;
     }
 
-    @keyframes slide-to-left {
-      to { opacity: 0; transform: translateX(-24px); }
-    }
-
-    @keyframes vt-fade-in {
-      from { opacity: 0; }
+    /* Main content: clip-path curtain wipe (A) */
+    @keyframes vt-wipe-in {
+      from { clip-path: inset(0 0 0 100%); }
+      to   { clip-path: inset(0 0 0 0); }
     }
 
     @keyframes vt-fade-out {
       to { opacity: 0; }
     }
 
-    @keyframes profile-in {
-      from { opacity: 0; transform: scale(0.92); }
+    ::view-transition-old(main-content) {
+      animation: 220ms ease-in vt-fade-out both;
     }
 
-    @keyframes profile-out {
-      to { opacity: 0; transform: scale(1.04); }
+    ::view-transition-new(main-content) {
+      animation: 400ms cubic-bezier(0.22, 1, 0.36, 1) vt-wipe-in both;
     }
 
-    @keyframes title-in {
-      from { opacity: 0; transform: translateY(10px); }
+    /* Page stripe: crossfade between page colors (C) */
+    @keyframes vt-fade-in {
+      from { opacity: 0; }
     }
 
-    @keyframes title-out {
-      to { opacity: 0; transform: translateY(-8px); }
+    ::view-transition-old(page-stripe) {
+      animation: 200ms ease-in vt-fade-out both;
     }
 
-    /* Root transition: slide the main content */
-    ::view-transition-old(root) {
-      animation: 220ms ease-in slide-to-left both;
+    ::view-transition-new(page-stripe) {
+      animation: 300ms ease-out vt-fade-in both;
     }
 
-    ::view-transition-new(root) {
-      animation: 280ms ease-out slide-from-right both;
-    }
-
-    /* Nav and footer: fast cross-fade in place */
-    ::view-transition-old(site-nav),
-    ::view-transition-old(site-footer) {
-      animation: 150ms ease-in vt-fade-out both;
-    }
-
-    ::view-transition-new(site-nav),
-    ::view-transition-new(site-footer) {
-      animation: 200ms ease-out vt-fade-in both;
-    }
-
-    /* Page title: subtle vertical slide */
-    ::view-transition-old(page-title) {
-      animation: 180ms ease-in title-out both;
-    }
-
-    ::view-transition-new(page-title) {
-      animation: 260ms ease-out title-in both;
-    }
-
-    /* Profile photo: gentle scale */
-    ::view-transition-old(profile-photo) {
-      animation: 200ms ease-in profile-out both;
-    }
-
-    ::view-transition-new(profile-photo) {
-      animation: 300ms ease-out profile-in both;
+    /* Section stagger on element insertion (B)
+       Transform-only (no opacity) so it doesn't conflict with the
+       clip-path screenshot. Sections rise up as the page wipes in. */
+    @keyframes vt-section-rise {
+      from { transform: translateY(22px); }
+      to   { transform: translateY(0); }
     }
   </style>
+
+  <script>
+    // Magic sliding nav indicator (A)
+    function updateNavIndicator() {
+      const active = document.querySelector('.nav-links a.active') as HTMLElement | null;
+      const indicator = document.getElementById('nav-indicator') as HTMLElement | null;
+      const navbar = document.querySelector('.navbar') as HTMLElement | null;
+      if (!indicator || !navbar) return;
+
+      if (active) {
+        const activeRect = active.getBoundingClientRect();
+        const navbarRect = navbar.getBoundingClientRect();
+        indicator.style.left = (activeRect.left - navbarRect.left) + 'px';
+        indicator.style.width = activeRect.width + 'px';
+        indicator.style.opacity = '1';
+      } else {
+        indicator.style.opacity = '0';
+      }
+    }
+
+    document.addEventListener('astro:page-load', updateNavIndicator);
+    updateNavIndicator();
+  </script>
 </body>
 </html>

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -2,10 +2,10 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout title="CV - Paola Valdivia" description="Curriculum Vitae">
+<BaseLayout title="CV - Paola Valdivia" description="Curriculum Vitae" pageColor="#0a402b">
   <div class="container">
     <div class="cv-header">
-      <h1 transition:name="page-title">Curriculum Vitae</h1>
+      <h1>Curriculum Vitae</h1>
       <a href="/files/PaolaValdivia_CV.pdf" class="download-btn" download>
         <img src="/img/curriculum-vitae.png" alt="" />
         Download PDF
@@ -26,6 +26,19 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 </BaseLayout>
 
 <style>
+  /* Section stagger (B) */
+  .cv-header {
+    animation: vt-section-rise 0.45s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
+  .cv-viewer {
+    animation: vt-section-rise 0.45s 0.07s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
+  .cv-footer {
+    animation: vt-section-rise 0.45s 0.14s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
   .cv-header {
     display: flex;
     justify-content: space-between;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,15 +2,15 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout title="Paola Valdivia - Software Engineer" description="Senior Software Engineer specializing in React, TypeScript, and C# with expertise in data visualization and full-stack development">
+<BaseLayout title="Paola Valdivia - Software Engineer" description="Senior Software Engineer specializing in React, TypeScript, and C# with expertise in data visualization and full-stack development" pageColor="#0a402b">
   <div class="container">
     <section class="hero">
       <div class="hero-content">
         <div class="profile-section">
-          <img src="/img/pao_f_small.png" alt="Paola Valdivia" class="profile-img" transition:name="profile-photo" />
+          <img src="/img/pao_f_small.png" alt="Paola Valdivia" class="profile-img" />
         </div>
         <div class="intro-section">
-          <h1 transition:name="page-title">Paola Valdivia</h1>
+          <h1>Paola Valdivia</h1>
           <p class="tagline">Senior Software Engineer</p>
           <p class="bio">
             Senior Software Engineer specializing in React, TypeScript, and C# with a proven
@@ -150,6 +150,23 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 </BaseLayout>
 
 <style>
+  /* Section stagger — transform only so it plays cleanly during clip-path wipe (B) */
+  .hero {
+    animation: vt-section-rise 0.45s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
+  .highlights {
+    animation: vt-section-rise 0.45s 0.07s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
+  .experience {
+    animation: vt-section-rise 0.45s 0.14s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
+  .education {
+    animation: vt-section-rise 0.45s 0.21s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
   .hero {
     margin: 3rem 0;
   }

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -45,9 +45,9 @@ const projects = [
 ];
 ---
 
-<BaseLayout title="Projects - Paola Valdivia" description="Research projects and visualization tools">
+<BaseLayout title="Projects - Paola Valdivia" description="Research projects and visualization tools" pageColor="#bb8462">
   <div class="container">
-    <h1 transition:name="page-title">Projects</h1>
+    <h1>Projects</h1>
     <p class="page-intro">
       A collection of research projects, visualization tools, and interactive demonstrations
       focused on network analysis, hypergraph visualization, and visual analytics.
@@ -80,6 +80,19 @@ const projects = [
 </BaseLayout>
 
 <style>
+  /* Section stagger (B) */
+  h1 {
+    animation: vt-section-rise 0.45s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
+  .page-intro {
+    animation: vt-section-rise 0.45s 0.07s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
+  .projects-grid {
+    animation: vt-section-rise 0.45s 0.14s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
   h1 {
     margin-bottom: 1rem;
   }

--- a/src/pages/publications.astro
+++ b/src/pages/publications.astro
@@ -48,9 +48,9 @@ const publications = [
 ];
 ---
 
-<BaseLayout title="Publications - Paola Valdivia" description="Academic publications and research papers">
+<BaseLayout title="Publications - Paola Valdivia" description="Academic publications and research papers" pageColor="#97461a">
   <div class="container">
-    <h1 transition:name="page-title">Publications</h1>
+    <h1>Publications</h1>
     <p class="page-intro">
       Research publications focusing on information visualization, hypergraph analysis,
       and network visualization techniques.
@@ -103,6 +103,23 @@ const publications = [
 </BaseLayout>
 
 <style>
+  /* Section stagger (B) */
+  h1 {
+    animation: vt-section-rise 0.45s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
+  .page-intro {
+    animation: vt-section-rise 0.45s 0.07s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
+  .publications-list {
+    animation: vt-section-rise 0.45s 0.14s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
+  .profiles {
+    animation: vt-section-rise 0.45s 0.21s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
   h1 {
     margin-bottom: 1rem;
   }


### PR DESCRIPTION
A — Clip-path curtain wipe: <main> transitions with a right-to-left
    clip-path reveal (cubic-bezier spring easing) instead of the barely-
    visible 24px slide. Nav/footer no longer participate — root gets
    animation:none so they swap instantly without distracting flashes.
    A small JS snippet positions a CSS-transitioned terracotta underline
    that slides between nav links on each navigation (magic line effect).

B — Section stagger: each page's major sections animate in sequentially
    via vt-section-rise (transform-only, 22px rise, 70ms stagger steps).
    Transform-only avoids opacity conflicts with view-transition screenshots.

C — Page accent stripe: a 4px colored stripe sits between the navbar and
    <main> with its own transition:name="page-stripe". Each page passes a
    pageColor prop (green / terracotta / terra-dark) so the stripe
    crossfades between page-specific colors on every navigation.

https://claude.ai/code/session_011iWoik23Po6SkzpHFyzMGh